### PR TITLE
Provide manual override capability through a couple of hacks to allow setting individual servo motor speeds.

### DIFF
--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -521,7 +521,7 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_long_packet(const mavlink_command_lon
         }
         return MAV_RESULT_ACCEPTED;
 
-    case 9999: // this is not taken, so lets give it a shot! For now this is the motor override command id YOLO
+    case 9999: // this is not taken, so lets give it a shot! For now this is the motor override command id. Sam Lensgraf 6/9/2019.
         if (!handle_raw_motor_override_packet(packet)) {
             return MAV_RESULT_FAILED;
         }
@@ -552,9 +552,9 @@ void copy_float_into_uints(float float_data, uint16_t* destination_1, uint16_t* 
     memcpy((void*)destination_2, dest_2_bytes, 2);
 }
 
-// This is hacky, but here is how it works. The "confirmation" byte is coopted here to
-// select up to 7 motors at once. Motor number i is selected if bit i is 1
-// in the confirmation byte.
+// unpacks the four floating point numbers given as the first four params of the COMMAND_LONG packet
+// into eight uint16_t values. The uint16_t is used in this codebase to hold values sent to the motors
+// as a PWM value
 bool GCS_MAVLINK_Sub::handle_raw_motor_override_packet(const mavlink_command_long_t &packet) {
     float motor_01_bytes = packet.param1;
     float motor_23_bytes = packet.param2;

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -534,20 +534,22 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_long_packet(const mavlink_command_lon
 }
 
 
-void copy_float_into_uints(float float_data, uint16_t& destination_1, uint16_t& destination_2) {
+void copy_float_into_uints(float float_data, uint16_t* destination_1, uint16_t* destination_2) {
     char data[4];
 
     char dest_1_bytes[2];
     char dest_2_bytes[2];
 
+    memcpy(data, &float_data, 4);
+
     dest_1_bytes[0] = data[0];
     dest_1_bytes[1] = data[1];
 
-    dest_2_bytes[0] = data[0];
-    dest_2_bytes[1] = data[1];
+    dest_2_bytes[0] = data[2];
+    dest_2_bytes[1] = data[3];
 
-    memcpy(destination_1, dest_1_bytes, 2);
-    memcpy(destination_2, dest_2_bytes, 2);
+    memcpy((void*)destination_1, dest_1_bytes, 2);
+    memcpy((void*)destination_2, dest_2_bytes, 2);
 }
 
 // This is hacky, but here is how it works. The "confirmation" byte is coopted here to
@@ -559,28 +561,28 @@ bool GCS_MAVLINK_Sub::handle_raw_motor_override_packet(const mavlink_command_lon
     float motor_45_bytes = packet.param3;
     float motor_67_bytes = packet.param4;
 
-    uint16_t motor_0;
-    uint16_t motor_1;
-    uint16_t motor_2;
-    uint16_t motor_3;
-    uint16_t motor_4;
-    uint16_t motor_5;
-    uint16_t motor_6;
-    uint16_t motor_7;
+    uint16_t motor_0_pwm;
+    uint16_t motor_1_pwm;
+    uint16_t motor_2_pwm;
+    uint16_t motor_3_pwm;
+    uint16_t motor_4_pwm;
+    uint16_t motor_5_pwm;
+    uint16_t motor_6_pwm;
+    uint16_t motor_7_pwm;
 
-    copy_float_into_uints(motor_01_bytes, motor_0, motor_1);
-    copy_float_into_uints(motor_23_bytes, motor_2, motor_3);
-    copy_float_into_uints(motor_45_bytes, motor_4, motor_5);
-    copy_float_into_uints(motor_67_bytes, motor_6, motor_7);
+    copy_float_into_uints(motor_01_bytes, &motor_0_pwm, &motor_1_pwm);
+    copy_float_into_uints(motor_23_bytes, &motor_2_pwm, &motor_3_pwm);
+    copy_float_into_uints(motor_45_bytes, &motor_4_pwm, &motor_5_pwm);
+    copy_float_into_uints(motor_67_bytes, &motor_6_pwm, &motor_7_pwm);
 
-    sub.motors.set_servo_channel_manual_override(0, motor_0);
-    sub.motors.set_servo_channel_manual_override(1, motor_1);
-    sub.motors.set_servo_channel_manual_override(2, motor_2);
-    sub.motors.set_servo_channel_manual_override(3, motor_3);
-    sub.motors.set_servo_channel_manual_override(4, motor_4);
-    sub.motors.set_servo_channel_manual_override(5, motor_5);
-    sub.motors.set_servo_channel_manual_override(6, motor_6);
-    sub.motors.set_servo_channel_manual_override(7, motor_7);
+    sub.motors.set_servo_channel_manual_override(0, motor_0_pwm);
+    sub.motors.set_servo_channel_manual_override(1, motor_1_pwm);
+    sub.motors.set_servo_channel_manual_override(2, motor_2_pwm);
+    sub.motors.set_servo_channel_manual_override(3, motor_3_pwm);
+    sub.motors.set_servo_channel_manual_override(4, motor_4_pwm);
+    sub.motors.set_servo_channel_manual_override(5, motor_5_pwm);
+    sub.motors.set_servo_channel_manual_override(6, motor_6_pwm);
+    sub.motors.set_servo_channel_manual_override(7, motor_7_pwm);
 
     return true;
 }

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -46,6 +46,8 @@ private:
     void handle_rc_channels_override(const mavlink_message_t *msg) override;
     bool try_send_message(enum ap_message id) override;
 
+    bool handle_raw_motor_override_packet(const mavlink_command_long_t &packet);
+
     bool send_info(void);
 
     MAV_MODE base_mode() const override;

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -576,8 +576,8 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored_6dof()
     }
 }
 
+// constrains the input pwm to the valid range and sets an override.
 void AP_Motors6DOF::set_servo_channel_manual_override(int8_t channel, uint16_t pwm) {
     _last_manual_servo_override_set = AP_HAL::millis();
-
-    _servo_channel_manual_overrides[channel] = pwm;
+    _servo_channel_manual_overrides[channel] = constrain_int16(pwm, _throttle_radio_min, _throttle_radio_max);
 }

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -567,8 +567,8 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored_6dof()
     }
 }
 
-void AP_Motors6DOF::set_servo_channel_manual_override(uint32_t channel, uint32_t pwm) {
-    _last_manual_override_set = AP_HAL::millis();
+void AP_Motors6DOF::set_servo_channel_manual_override(int8_t channel, uint16_t pwm) {
+    _last_manual_servo_override_set = AP_HAL::millis();
 
     _servo_channel_manual_overrides[channel] = pwm;
 }

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -272,8 +272,18 @@ void AP_Motors6DOF::output_to_motors()
     }
 }
 
+// returns true if the code should allow our hacky implementation of manually set speed
+// overrides to be used.
 bool AP_Motors6DOF::should_use_manual_override() {
     uint32_t current_time = AP_HAL::millis();
+
+    // what is a spool state? no idea. The function that calls this one
+    // explicity sets the motors to neutral if any of these
+    bool spool_state_requires_neutral_motors = _spool_state == SpoolState::SHUT_DOWN || _spool_state == SpoolState::GROUND_IDLE;
+
+    if (spool_state_requires_neutral_motors) {
+        return false; 
+    }
 
     // if this if statement passes, the clock probably wrapped back around 
     if (current_time < _last_manual_servo_override_set) {

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -19,7 +19,6 @@
 
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_HAL/AP_HAL.h>
-#include <GCS_MAVLink/GCS.h>
 #include "AP_Motors6DOF.h"
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -46,7 +46,7 @@ public:
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo        var_info[];
 
-    void set_servo_channel_manual_override(uint32_t channel, uint32_t pwm);
+    void set_servo_channel_manual_override(int8_t channel, uint16_t pwm);
 
 protected:
     // return current_limit as a number from 0 ~ 1 in the range throttle_min to throttle_max

--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -8,6 +8,8 @@
 #include <RC_Channel/RC_Channel.h>     // RC Channel Library
 #include "AP_MotorsMatrix.h"
 
+const uint32_t AP_MOTORS_MANUAL_OVERRIDE_DURATION_MILLIS(500);
+
 /// @class      AP_MotorsMatrix
 class AP_Motors6DOF : public AP_MotorsMatrix {
 public:
@@ -44,6 +46,8 @@ public:
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo        var_info[];
 
+    void set_servo_channel_manual_override(uint32_t channel, uint32_t pwm);
+
 protected:
     // return current_limit as a number from 0 ~ 1 in the range throttle_min to throttle_max
     float               get_current_limit_max_throttle() override;
@@ -59,6 +63,10 @@ protected:
     AP_Int8             _motor_reverse[AP_MOTORS_MAX_NUM_MOTORS];
     AP_Float            _forwardVerticalCouplingFactor;
 
+    // manual override by Sam Lensgraf
+    int16_t             _servo_channel_manual_overrides[AP_MOTORS_MAX_NUM_MOTORS];
+    uint32_t            _last_manual_servo_override_set;
+
     float               _throttle_factor[AP_MOTORS_MAX_NUM_MOTORS]; // each motors contribution to throttle (climb/descent)
     float               _forward_factor[AP_MOTORS_MAX_NUM_MOTORS]; // each motors contribution to forward/backward
     float               _lateral_factor[AP_MOTORS_MAX_NUM_MOTORS];  // each motors contribution to lateral (left/right)
@@ -66,4 +74,9 @@ protected:
     // current limiting
     float _output_limited = 1.0f;
     float _batt_current_last = 0.0f;
+
+    // returns true if the manual overrides
+    // set in _servo_channel_manual_overrides have been updated within
+    // AP_MOTORS_MANUAL_OVERRIDE_DURATION_MILLIS milliseconds
+    bool should_use_manual_override();
 };

--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -33,7 +33,7 @@ bool AP_ServoRelayEvents::do_set_servo(uint8_t _channel, uint16_t pwm)
         return false;
     }
     if (c->get_function() != SRV_Channel::k_none) {
-        gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use.", _channel);
+        gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
         return false;
     }
     if (type == EVENT_TYPE_SERVO && 

--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -33,7 +33,7 @@ bool AP_ServoRelayEvents::do_set_servo(uint8_t _channel, uint16_t pwm)
         return false;
     }
     if (c->get_function() != SRV_Channel::k_none) {
-        gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use. HETHTEHJGFHJAFG", _channel);
+        gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use.", _channel);
         return false;
     }
     if (type == EVENT_TYPE_SERVO && 

--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -33,8 +33,8 @@ bool AP_ServoRelayEvents::do_set_servo(uint8_t _channel, uint16_t pwm)
         return false;
     }
     if (c->get_function() != SRV_Channel::k_none) {
-        gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
-        return false;
+        gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use. HETHTEHJGFHJAFG", _channel);
+        //return false;
     }
     if (type == EVENT_TYPE_SERVO && 
         channel == _channel) {
@@ -74,7 +74,7 @@ bool AP_ServoRelayEvents::do_repeat_servo(uint8_t _channel, uint16_t _servo_valu
     }
     if (c->get_function() != SRV_Channel::k_none) {
         gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
-        return false;
+        //return false;
     }
     channel = _channel;
     type = EVENT_TYPE_SERVO;

--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -34,7 +34,7 @@ bool AP_ServoRelayEvents::do_set_servo(uint8_t _channel, uint16_t pwm)
     }
     if (c->get_function() != SRV_Channel::k_none) {
         gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use. HETHTEHJGFHJAFG", _channel);
-        //return false;
+        return false;
     }
     if (type == EVENT_TYPE_SERVO && 
         channel == _channel) {
@@ -74,7 +74,7 @@ bool AP_ServoRelayEvents::do_repeat_servo(uint8_t _channel, uint16_t _servo_valu
     }
     if (c->get_function() != SRV_Channel::k_none) {
         gcs().send_text(MAV_SEVERITY_INFO, "ServoRelayEvent: Channel %d is already in use", _channel);
-        //return false;
+        return false;
     }
     channel = _channel;
     type = EVENT_TYPE_SERVO;


### PR DESCRIPTION
This PR enables us to send a mavlink COMMAND_LONG command with parameters to set each of the eight motors on our ardusub's frame.

In `ArduSub/GCS_Mavlink.cpp`, a new case which accepts a new type of COMMAND_LONG is added. Currently, the id of the command is set to `9999` which is a number I picked by looking through the types of COMMAND_LONG commands in the mavlink message definition. I'm pretty sure it isn't taken.

The COMMAND_LONG message has a `command_id` and allows seven floating point parameters to be set. To communicate the motor speed for eight motors with at most seven parameters required a hack. Because each floating point number is four bytes and we only need two to describe a valid pwm value, the floating point numbers are converted into byte arrays. The byte array is then reinterpreted as a pair of `uint16_t` values. Below I provide example code of how to send a message with roscpp.

With the motor speeds in hand, the code which parses this new COMMAND_LONG sets two values in the `AP_Motors6DOF` object which manages the motors of the sub. It sets the last time in milliseconds an override was set and it fills in a pwm value in an internal array on the class. The override values in the override array are only used if the last time an override was set is within `AP_MOTORS_MANUAL_OVERRIDE_DURATION_MILLIS` (initially half a second) of the time that the pwm values are being sent to the motors. If more time than this amount has passed, the overrides are ignored.

Usage example:

```cpp
void pack_uints_into_float(uint16_t first_uint, uint16_t second_uint, float* destination) {
    // separate the first uint out into bytes
    // and the second one
    // then memcpy their bytes into the destination
    char first_uint_bytes[2];
    char second_uint_bytes[2];

    char float_bytes[4];

    memcpy(first_uint_bytes, &first_uint, 2);
    memcpy(second_uint_bytes, &second_uint, 2);

    float_bytes[0] = first_uint_bytes[0];
    float_bytes[1] = first_uint_bytes[1];
    float_bytes[2] = second_uint_bytes[0];
    float_bytes[3] = second_uint_bytes[1];

    memcpy(destination, float_bytes, 4);
}


void set_motor_speeds(std::array<uint16_t, 8> speeds) {
    mavros_msgs::CommandLong::Request request;
    mavros_msgs::CommandLong::Response response;

    request.command = 9999; // my hacky command id. It didn't look like this one was taken

    pack_uints_into_float(speeds[0], speeds[1], &(request.param1));
    pack_uints_into_float(speeds[2], speeds[3], &(request.param2));
    pack_uints_into_float(speeds[4], speeds[5], &(request.param3));
    pack_uints_into_float(speeds[6], speeds[7], &(request.param4));

    send_request_to_ros_service(MAVROS_GENERAL_COMMAND_SERVICE, request, response);
}


int main(int argc, char** argv) {
    ros::init(argc, argv, "samlensgraf_bluerov_controller");
    ros::NodeHandle node_handle;

    arm_motors();

    std::array<uint16_t, 8> test_motor_speeds {
        500,
        1500,
        500,
        500,
        1500,
        1500,
        1500,
        1500
    };

    ros::Rate rate(1);
    while (ros::ok()) {
        set_motor_speeds(test_motor_speeds);
        rate.sleep();
    }

    return 0;
}

```